### PR TITLE
Refactor MIB parser

### DIFF
--- a/esa-base/src/Data/TM/LogarithmicCalibration.hs
+++ b/esa-base/src/Data/TM/LogarithmicCalibration.hs
@@ -64,7 +64,7 @@ data LogarithmicCalibration = LogarithmicCalibration {
     , _la3 :: !Double
     , _la4 :: !Double
     }
-    deriving(Show, Generic)
+    deriving(Eq, Show, Generic)
 makeLenses ''LogarithmicCalibration
 
 instance NFData LogarithmicCalibration

--- a/esa-base/src/Data/TM/NumericalCalibration.hs
+++ b/esa-base/src/Data/TM/NumericalCalibration.hs
@@ -49,7 +49,7 @@ data CalibPoint = CalibPoint {
     _cx :: !Double
     , _cy :: !Double
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 makeLenses ''CalibPoint
 
 instance NFData CalibPoint
@@ -70,7 +70,7 @@ data NumericalCalibration = NumericalCalibration {
     , _calibNInterpolation :: !CalibInterpolation
     , _calibNPoints :: Vector CalibPoint
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 makeLenses ''NumericalCalibration
 
 instance NFData NumericalCalibration

--- a/esa-base/src/Data/TM/PolynomialCalibration.hs
+++ b/esa-base/src/Data/TM/PolynomialCalibration.hs
@@ -64,7 +64,7 @@ data PolynomialCalibration = PolynomialCalibration {
     , _pa3 :: !Double
     , _pa4 :: !Double
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 makeLenses ''PolynomialCalibration
 
 instance NFData PolynomialCalibration

--- a/esa-base/src/Data/TM/TextualCalibration.hs
+++ b/esa-base/src/Data/TM/TextualCalibration.hs
@@ -58,7 +58,7 @@ data TextCalibPoint = TextCalibPoint {
     -- value falls within the range [lower, upper] (inclusive)
     , _txpText :: !ShortText
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 makeLenses ''TextCalibPoint
 
 instance NFData TextCalibPoint
@@ -74,7 +74,7 @@ data TextualCalibration = TextualCalibration {
         , _calibTRawFmt :: !NumType
         , _calibTPoints :: Vector TextCalibPoint
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 
 instance NFData TextualCalibration
 instance Serialise TextualCalibration

--- a/esa-mib/esa-mib.cabal
+++ b/esa-mib/esa-mib.cabal
@@ -242,7 +242,8 @@ test-suite esa-mib-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      Spec.Parser
+      Spec.Parser,
+      Spec.Calibration
   hs-source-dirs:
       test
   default-extensions:
@@ -254,5 +255,6 @@ test-suite esa-mib-test
       cassava,
       hspec,
       vector,
+      esa-base,
       esa-mib
   default-language: Haskell2010

--- a/esa-mib/esa-mib.cabal
+++ b/esa-mib/esa-mib.cabal
@@ -236,3 +236,23 @@ executable LoadMIBTest
         pretty-show,
         vector,
         hashtables-mo
+
+
+test-suite esa-mib-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Spec.Parser
+  hs-source-dirs:
+      test
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -Wall -Werror -O2 -funbox-strict-fields
+  build-depends:
+      base >=4.7 && <5,
+      bytestring,
+      cassava,
+      hspec,
+      vector,
+      esa-mib
+  default-language: Haskell2010

--- a/esa-mib/src/Data/Conversion/Calibration.hs
+++ b/esa-mib/src/Data/Conversion/Calibration.hs
@@ -1,15 +1,3 @@
-{-# LANGUAGE OverloadedStrings
-    , BangPatterns
-    , GeneralizedNewtypeDeriving
-    , DeriveGeneric
-    , RecordWildCards
-    , NoImplicitPrelude
-    , BinaryLiterals
-    , NumericUnderscores
-    , FlexibleInstances
-    , GADTs
-    , ExistentialQuantification
-#-}
 module Data.Conversion.Calibration
     ( convertNumCalib
     , convertPolyCalib
@@ -21,9 +9,7 @@ where
 import           RIO
 import qualified RIO.Text                      as T
 import qualified RIO.Vector                    as V
-import           RIO.List                       ( sortBy
-                                                , intersperse
-                                                )
+import           RIO.List                       ( sortBy )
 import           Data.Text.Short                ( toText )
 
 import           Data.MIB.Types
@@ -41,10 +27,6 @@ import           Data.TM.LogarithmicCalibration
 import           Data.TM.TextualCalibration
 import           Data.TM.Value
 
-import           Control.Monad.Except
-
-
-
 
 -- | Convert from MIB structure to a TM model structure. In this case
 -- the standard numerical calibration is converted.
@@ -52,139 +34,91 @@ import           Control.Monad.Except
 -- is provided.
 convertNumCalib
     :: CAFentry -> Vector CAPentry -> Either Text NumericalCalibration
-convertNumCalib CAFentry {..} caps =
-    let points = getCaps
-    in  if all isRight points
-            then
-                let points' = rights points
-                in  Right NumericalCalibration
-                        { _calibNName          = _cafNumbr
-                        , _calibNDescr         = _cafDescr
-                        , _calibNInterpolation = toCalibInterpolation (getDefaultChar _cafInter)
-                        , _calibNPoints        = V.fromList points'
-                        }
-            else
-                Left
-                $  T.concat
-                .  intersperse "\n"
-                $  ["Conversion to NumericalCalibration " <> toText _cafNumbr]
-                <> lefts points
+convertNumCalib CAFentry {..} caps
+    = mapLeft errInfo
+    $ NumericalCalibration
+        <$> pure _cafNumbr
+        <*> pure _cafDescr
+        <*> pure (toCalibInterpolation $ getDefaultChar _cafInter)
+        <*> (fmap V.fromList) (sequence points)
   where
-    getCaps =
-        let
-            v1 = map conv . sortBy s . filter f $ V.toList caps
-            f x = _capNumbr x == _cafNumbr
-            s x y = compare (_capXVals x) (_capXVals y)
-            conv CAPentry {..} =
-                let
-                    x = parseShortTextToDouble (charToType _cafRawFmt)
-                                               (charToRadix _cafRadix)
-                                               _capXVals
-                    y = parseShortTextToDouble (charToType _cafEngFmt)
-                                               Decimal
-                                               _capYVals
-                    chk (Left e)   _          = Left e
-                    chk _          (Left  e ) = Left e
-                    chk (Right !x1) (Right !y1) = Right $ CalibPoint x1 y1
-                in
-                    chk x y
-        in
-            v1
+    errInfo _
+        =  T.unlines
+        $  ["Conversion to NumericalCalibration " <> toText _cafNumbr]
+        <> lefts points
+    points = map conv . sortBy s . filter f $ V.toList caps
+    f x = _capNumbr x == _cafNumbr
+    s x y = compare (_capXVals x) (_capXVals y)
+    conv CAPentry {..}
+        = CalibPoint
+            <$> parseShortTextToDouble
+                (charToType _cafRawFmt)
+                (charToRadix _cafRadix)
+                _capXVals
+            <*> parseShortTextToDouble
+                (charToType _cafEngFmt)
+                Decimal
+                _capYVals
 
 
 convertTextCalib
     :: TXFentry -> Vector TXPentry -> Either Text TextualCalibration
-convertTextCalib TXFentry {..} vec =
-    let points = getPoints rawFmt
-        rawFmt = charToType _txfRawFmt
-    in  if all isRight points
-            then
-                let points' = rights points
-                in  Right TextualCalibration
-                        { _calibTName   = _txfNumbr
-                        , _calibTDescr  = _txfDescr
-                        , _calibTRawFmt = rawFmt
-                        , _calibTPoints = V.fromList points'
-                        }
-            else
-                Left
-                $  T.concat
-                .  intersperse "\n"
-                $  ["Conversion to TextualCalibration " <> toText _txfNumbr]
-                <> lefts points
+convertTextCalib TXFentry {..} vec
+    = mapLeft errInfo
+    $ TextualCalibration
+        <$> pure _txfNumbr
+        <*> pure _txfDescr
+        <*> pure rawFmt
+        <*> fmap V.fromList (sequence points)
   where
-    getPoints rawFmt =
-        let v1 = map chk . filter f $ V.toList vec
-            f x = _txpNumbr x == _txfNumbr
-            chk TXPentry {..} = runExcept $ do
-                from <- liftEither
-                    $ parseShortTextToInt64 rawFmt Decimal _txpFrom
-                to' <- liftEither $ parseShortTextToInt64 rawFmt Decimal _txpTo
-                pure (TextCalibPoint from to' _txpAlTxt)
-        in  v1
-
+    errInfo _
+        =  T.unlines
+        $  ["Conversion to TextualCalibration " <> toText _txfNumbr]
+        <> lefts points
+    points = map toPoint . filter f $ V.toList vec
+    f x = _txpNumbr x == _txfNumbr
+    toPoint TXPentry {..} = TextCalibPoint
+        <$> parseShortTextToInt64 rawFmt Decimal _txpFrom
+        <*> parseShortTextToInt64 rawFmt Decimal _txpTo
+        <*> pure _txpAlTxt
+    rawFmt = charToType _txfRawFmt
 
 
 -- | Convert a 'MCFentry' to the 'PolynomialCalibration' type. Returns
 -- an error message if the data cannot be parsed
 convertPolyCalib :: MCFentry -> Either Text PolynomialCalibration
-convertPolyCalib MCFentry {..} = case conv of
-    Left err ->
-        Left $ "Conversion to PolynomialCalibration " <> toText _mcfIdent <> err
-    Right (a0, a1, a2, a3, a4) -> Right PolynomialCalibration
-        { _calibPName  = _mcfIdent
-        , _calibPDescr = _mcfDescr
-        , _pa0         = a0
-        , _pa1         = a1
-        , _pa2         = a2
-        , _pa3         = a3
-        , _pa4         = a4
-        }
+convertPolyCalib MCFentry {..}
+    = mapLeft errInfo
+    $ PolynomialCalibration
+        <$> pure _mcfIdent
+        <*> pure _mcfDescr
+        <*> f _mcfPol1
+        <*> f _mcfPol2
+        <*> f _mcfPol3
+        <*> f _mcfPol4
+        <*> f _mcfPol5
   where
-    f =
-        liftEither
-            . parseShortTextToDouble NumDouble Decimal
-            . getDefaultShortText
-    conv = runExcept $ do
-        a0 <- f _mcfPol1
-        a1 <- f _mcfPol2
-        a2 <- f _mcfPol3
-        a3 <- f _mcfPol4
-        a4 <- f _mcfPol5
-        pure (a0, a1, a2, a3, a4)
-
-
-
+    errInfo err = "Conversion to PolynomialCalibration "
+        <> toText _mcfIdent
+        <> err
+    f = parseShortTextToDouble NumDouble Decimal
+        . getDefaultShortText
 
 
 convertLogCalib :: LGFentry -> Either Text LogarithmicCalibration
-convertLogCalib LGFentry {..} = case conv of
-    Left err ->
-        Left
-            $  "Conversion to LogarithmicCalibration "
-            <> toText _lgfIdent
-            <> err
-    Right (a0, a1, a2, a3, a4) -> Right LogarithmicCalibration
-        { _calibLName  = _lgfIdent
-        , _calibLDescr = _lgfDescr
-        , _la0         = a0
-        , _la1         = a1
-        , _la2         = a2
-        , _la3         = a3
-        , _la4         = a4
-        }
+convertLogCalib LGFentry {..}
+    = mapLeft errInfo
+    $ LogarithmicCalibration
+        <$> pure _lgfIdent
+        <*> pure _lgfDescr
+        <*> f _lgfPol1
+        <*> f _lgfPol2
+        <*> f _lgfPol3
+        <*> f _lgfPol4
+        <*> f _lgfPol5
   where
-    f =
-        liftEither
-            . parseShortTextToDouble NumDouble Decimal
-            . getDefaultShortText
-    conv = runExcept $ do
-        a0 <- f _lgfPol1
-        a1 <- f _lgfPol2
-        a2 <- f _lgfPol3
-        a3 <- f _lgfPol4
-        a4 <- f _lgfPol5
-        pure (a0, a1, a2, a3, a4)
-
-
-
+    errInfo err = "Conversion to LogarithmicCalibration "
+        <> toText _lgfIdent
+        <> err
+    f = parseShortTextToDouble NumDouble Decimal
+        . getDefaultShortText

--- a/esa-mib/src/Data/MIB/CAF.hs
+++ b/esa-mib/src/Data/MIB/CAF.hs
@@ -6,13 +6,12 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
-
+import qualified Data.Vector                   as V
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
 import           Data.MIB.Load
-import Data.MIB.Types
+import           Data.MIB.Types
 
 
 data CAFentry = CAFentry {
@@ -27,49 +26,11 @@ data CAFentry = CAFentry {
 } deriving (Eq, Show)
 
 
-
-
-
 instance FromRecord CAFentry where
   parseRecord v
-    | V.length v == 8
-    = CAFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-      <*> v
-      .!  7
-      | V.length v == 7
-      = CAFentry
-        <$> v
-        .!  0
-        <*> v
-        .!  1
-        <*> v
-        .!  2
-        <*> v
-        .!  3
-        <*> v
-        .!  4
-        <*> v
-        .!  5
-        <*> v
-        .!  6
-        <*> pure (CharDefaultTo 'F')
-      | otherwise
-    = mzero
-
+    | V.length v == 8 = genericParse (const True) CAFentry v
+    | V.length v == 7 = genericParse (const True) CAFentry $ V.snoc v "F"
+    | otherwise = mzero
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/CAP.hs
+++ b/esa-mib/src/Data/MIB/CAP.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE
-    OverloadedStrings
-    , BangPatterns
+      BangPatterns
     , NoImplicitPrelude
 #-}
 module Data.MIB.CAP
@@ -10,8 +9,6 @@ module Data.MIB.CAP
 where
 
 import           RIO
-
-import qualified RIO.Vector                    as V
 
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
@@ -26,21 +23,8 @@ data CAPentry = CAPentry {
 } deriving (Eq, Show)
 
 
-
-
-
 instance FromRecord CAPentry where
-  parseRecord v
-    | V.length v == 3
-    = CAPentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-    | otherwise
-    = mzero
+  parseRecord = genericParse (== 3) CAPentry
 
 
 

--- a/esa-mib/src/Data/MIB/CUR.hs
+++ b/esa-mib/src/Data/MIB/CUR.hs
@@ -11,7 +11,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -29,15 +28,8 @@ data CURentry = CURentry {
 instance Ord CURentry where
     compare x1 x2 = compare (_curPos x1) (_curPos x2)
 
-
-
 instance FromRecord CURentry where
-  parseRecord v
-    | V.length v == 5
-    = CURentry <$> v .! 0 <*> v .! 1 <*> v .! 2 <*> v .! 3 <*> v .! 4
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 5) CURentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/GPC.hs
+++ b/esa-mib/src/Data/MIB/GPC.hs
@@ -6,7 +6,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -33,34 +32,7 @@ instance Ord GPCentry where
   compare x1 x2 = compare (_gpcName x1) (_gpcName x2)
 
 instance FromRecord GPCentry where
-  parseRecord v
-    | V.length v == 11
-    = GPCentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-      <*> v
-      .!  7
-      <*> v
-      .!  8
-      <*> v
-      .!  9
-      <*> v
-      .!  10
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 11) GPCentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/GPF.hs
+++ b/esa-mib/src/Data/MIB/GPF.hs
@@ -6,7 +6,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -36,40 +35,7 @@ instance Ord GPFentry where
   compare x1 x2 = compare (_gpfName x1) (_gpfName x2)
 
 instance FromRecord GPFentry where
-  parseRecord v
-    | V.length v == 14
-    = GPFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-      <*> v
-      .!  7
-      <*> v
-      .!  8
-      <*> v
-      .!  9
-      <*> v
-      .!  10
-      <*> v
-      .!  11
-      <*> v
-      .!  12
-      <*> v
-      .!  13
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 14) GPFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/LGF.hs
+++ b/esa-mib/src/Data/MIB/LGF.hs
@@ -12,8 +12,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
-
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -33,29 +31,8 @@ data LGFentry = LGFentry {
 
 
 
-
-
 instance FromRecord LGFentry where
-  parseRecord v
-    | V.length v == 7
-    = LGFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 7) LGFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/MCF.hs
+++ b/esa-mib/src/Data/MIB/MCF.hs
@@ -12,8 +12,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
-
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -32,30 +30,8 @@ data MCFentry = MCFentry {
 } deriving (Eq, Show)
 
 
-
-
-
 instance FromRecord MCFentry where
-  parseRecord v
-    | V.length v == 7
-    = MCFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 7) MCFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/PCF.hs
+++ b/esa-mib/src/Data/MIB/PCF.hs
@@ -37,11 +37,11 @@ module Data.MIB.PCF
 where
 
 import           RIO
-import qualified RIO.Vector                    as V
 import           RIO.HashMap                   as HM
 
 import           Control.Lens                   ( makeLenses )
 
+import qualified Data.Vector                   as V
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -91,104 +91,15 @@ instance Eq PCFentry where
     pcf1 == pcf2 = _pcfName pcf1 == _pcfName pcf2
 
 
-
 instance FromRecord PCFentry where
-    parseRecord v
-        | V.length v >= 23
-        = PCFentry
-            <$> v
-            .!  0
-            <*> v
-            .!  1
-            <*> v
-            .!  2
-            <*> v
-            .!  3
-            <*> v
-            .!  4
-            <*> v
-            .!  5
-            <*> v
-            .!  6
-            <*> v
-            .!  7
-            <*> v
-            .!  8
-            <*> v
-            .!  9
-            <*> v
-            .!  10
-            <*> v
-            .!  11
-            <*> v
-            .!  12
-            <*> v
-            .!  13
-            <*> v
-            .!  14
-            <*> v
-            .!  15
-            <*> v
-            .!  16
-            <*> v
-            .!  17
-            <*> v
-            .!  18
-            <*> v
-            .!  19
-            <*> v
-            .!  20
-            <*> v
-            .!  21
-            <*> v
-            .!  22
-        | V.length v >= 19
-        = PCFentry
-            <$> v
-            .!  0
-            <*> v
-            .!  1
-            <*> v
-            .!  2
-            <*> v
-            .!  3
-            <*> v
-            .!  4
-            <*> v
-            .!  5
-            <*> v
-            .!  6
-            <*> v
-            .!  7
-            <*> v
-            .!  8
-            <*> v
-            .!  9
-            <*> v
-            .!  10
-            <*> v
-            .!  11
-            <*> v
-            .!  12
-            <*> v
-            .!  13
-            <*> v
-            .!  14
-            <*> v
-            .!  15
-            <*> v
-            .!  16
-            <*> v
-            .!  17
-            <*> v
-            .!  18
-            <*> pure (CharDefaultTo 'Y')
-            <*> pure Nothing
-            <*> pure Nothing
-            <*> pure Nothing
-        | otherwise
-        = mzero
-
+  parseRecord v
+      | V.length v >= 23 = genericParse (const True) PCFentry v
+      | V.length v >= 19 = genericParse (const True) PCFentry
+          $ V.concat
+              [ V.unsafeSlice 0 19 v
+              , V.fromList ["", "", "", ""]
+              ]
+      | otherwise = mzero
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/PIC.hs
+++ b/esa-mib/src/Data/MIB/PIC.hs
@@ -36,6 +36,7 @@ import           Data.Vector.Algorithms.Merge  as V
 import           System.Directory
 import           System.FilePath
 
+import           Data.MIB.Load (genericParse)
 import           Data.MIB.Types
 
 
@@ -76,39 +77,9 @@ instance Hashable PICentry where
 
 instance FromRecord PICentry where
   parseRecord v
-    | V.length v >= 7
-    = PICentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-    | V.length v >= 6
-    = PICentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> pure Nothing
-    | otherwise
-    = mzero
+      | V.length v >= 7 = genericParse (const True) PICentry v
+      | V.length v >= 6 = genericParse (const True) PICentry $ V.snoc v ""
+      | otherwise = mzero
 
 myOptions :: DecodeOptions
 myOptions = defaultDecodeOptions { decDelimiter = fromIntegral (ord '\t') }

--- a/esa-mib/src/Data/MIB/PID.hs
+++ b/esa-mib/src/Data/MIB/PID.hs
@@ -29,7 +29,6 @@ import           Control.Lens                   ( makeLenses )
 
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
-import qualified RIO.Vector                    as V
 
 import           Data.MIB.Load
 import           Data.MIB.Types
@@ -76,45 +75,7 @@ getPidTime pid = case getDefaultChar (_pidTime pid) of
 
 
 instance FromRecord PIDentry where
-    parseRecord v
-        | V.length v >= 16
-        = PIDentry
-            <$> v
-            .!  0
-            <*> v
-            .!  1
-            <*> v
-            .!  2
-            <*> v
-            .!  3
-            <*> v
-            .!  4
-            <*> v
-            .!  5
-            <*> v
-            .!  6
-            <*> v
-            .!  7
-            <*> v
-            .!  8
-            <*> v
-            .!  9
-            <*> v
-            .!  10
-            <*> v
-            .!  11
-            <*> v
-            .!  12
-            <*> v
-            .!  13
-            <*> v
-            .!  14
-            <*> v
-            .!  15
-        | otherwise
-        = mzero
-
-
+  parseRecord = genericParse (>= 16) PIDentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/PLF.hs
+++ b/esa-mib/src/Data/MIB/PLF.hs
@@ -16,8 +16,6 @@ module Data.MIB.PLF
 where
 
 import           RIO
-import qualified RIO.Vector                    as V
---import qualified RIO.HashMap                   as HM
 import           Control.Lens                   ( makeLenses )
 
 import           Data.Text.Short                ( ShortText )
@@ -55,27 +53,7 @@ instance Ord PLFentry where
 
 
 instance FromRecord PLFentry where
-  parseRecord v
-    | V.length v >= 8
-    = PLFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-      <*> v
-      .!  7
-    | otherwise
-    = mzero
+  parseRecord = genericParse (>= 8) PLFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/TPCF.hs
+++ b/esa-mib/src/Data/MIB/TPCF.hs
@@ -35,9 +35,7 @@ instance Eq TPCFentry where
 
 
 instance FromRecord TPCFentry where
-  parseRecord v | V.length v == 3 = TPCFentry <$> v .! 0 <*> v .! 1 <*> v .! 2
-                | otherwise       = mzero
-
+  parseRecord = genericParse (== 3) TPCFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/TXF.hs
+++ b/esa-mib/src/Data/MIB/TXF.hs
@@ -11,8 +11,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
-
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -29,20 +27,7 @@ data TXFentry = TXFentry {
 
 
 instance FromRecord TXFentry where
-  parseRecord v
-    | V.length v == 4
-    = TXFentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 4) TXFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/TXP.hs
+++ b/esa-mib/src/Data/MIB/TXP.hs
@@ -11,8 +11,6 @@ where
 
 import           RIO
 
-import qualified RIO.Vector                    as V
-
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
 
@@ -31,20 +29,7 @@ data TXPentry = TXPentry {
 
 
 instance FromRecord TXPentry where
-  parseRecord v
-    | V.length v == 4
-    = TXPentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 4) TXPentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/VDF.hs
+++ b/esa-mib/src/Data/MIB/VDF.hs
@@ -14,7 +14,6 @@ import           RIO
 
 import           Data.Text.Short                ( ShortText )
 import           Data.Csv
-import qualified RIO.Vector                    as V
 import qualified RIO.Vector.Partial            as V
                                                 ( last )
 
@@ -34,12 +33,7 @@ data VDFentry = VDFentry {
 
 
 instance FromRecord VDFentry where
-  parseRecord v
-    | V.length v == 5
-    = VDFentry <$> v .! 0 <*> v .! 1 <*> v .! 2 <*> v .! 3 <*> v .! 4
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (== 5) VDFentry
 
 
 fileName :: FilePath

--- a/esa-mib/src/Data/MIB/VPD.hs
+++ b/esa-mib/src/Data/MIB/VPD.hs
@@ -80,40 +80,7 @@ instance Ord VPDentry where
 
 
 instance FromRecord VPDentry where
-  parseRecord v
-    | V.length v >= 13
-    = VPDentry
-      <$> v
-      .!  0
-      <*> v
-      .!  1
-      <*> v
-      .!  2
-      <*> v
-      .!  3
-      <*> v
-      .!  4
-      <*> v
-      .!  5
-      <*> v
-      .!  6
-      <*> v
-      .!  7
-      <*> v
-      .!  8
-      <*> v
-      .!  9
-      <*> v
-      .!  10
-      <*> v
-      .!  11
-      <*> v
-      .!  12
-      <*> v
-      .!  13
-    | otherwise
-    = mzero
-
+  parseRecord = genericParse (>= 13) VPDentry
 
 
 fileName :: FilePath

--- a/esa-mib/test/Spec.hs
+++ b/esa-mib/test/Spec.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import           Test.Hspec
+import           Spec.Parser (parserSpec)
+
+
+main :: IO ()
+main = hspec $ parallel $ do
+  parserSpec

--- a/esa-mib/test/Spec.hs
+++ b/esa-mib/test/Spec.hs
@@ -2,8 +2,10 @@ module Main (main) where
 
 import           Test.Hspec
 import           Spec.Parser (parserSpec)
+import           Spec.Calibration (calibrationSpec)
 
 
 main :: IO ()
 main = hspec $ parallel $ do
   parserSpec
+  calibrationSpec

--- a/esa-mib/test/Spec/Calibration.hs
+++ b/esa-mib/test/Spec/Calibration.hs
@@ -1,0 +1,101 @@
+module Spec.Calibration where
+
+import           Test.Hspec
+
+import qualified Data.Vector as V
+import           Data.MIB.Types
+import           Data.MIB.CAF
+import           Data.MIB.CAP
+import           Data.MIB.MCF
+import           Data.MIB.LGF
+import           Data.MIB.TXF
+import           Data.MIB.TXP
+import           Data.Conversion.Calibration
+
+import           Data.TM.CalibrationTypes
+import           Data.TM.NumericalCalibration
+import           Data.TM.PolynomialCalibration
+import           Data.TM.LogarithmicCalibration
+import           Data.TM.TextualCalibration
+import           Data.TM.Value
+
+
+calibrationSpec :: Spec
+calibrationSpec = describe "Calibration conversion" $ do
+  it "can convert CAF & CAP" $ do
+    let numb = "5"
+    let desc = "TM NUm Curve"
+    let caf = CAFentry numb desc 'R' 'R' 'D' "Ohm" 2 (CharDefaultTo 'F')
+    let caps = V.fromList
+          [ CAPentry numb "9" "0.8"
+          , CAPentry "8" "3" "0.4"
+          , CAPentry numb "5" "0.6"
+          ]
+
+    convertNumCalib caf caps `shouldBe`
+      Right (NumericalCalibration
+        { _calibNName = numb
+        , _calibNDescr = desc
+        , _calibNInterpolation = CalibFail
+        , _calibNPoints = V.fromList
+          [ CalibPoint 5.0 0.6
+          , CalibPoint 9.0 0.8
+          ]
+        })
+
+  it "can convert TXF & TXP" $ do
+    let numb = "136"
+    let desc = "TM Text Curve 36"
+    let txf = TXFentry numb desc 'U' (Just 16)
+    let txps = V.fromList
+          [ TXPentry numb "5" "62" "INVALID"
+          , TXPentry "10" "1" "62" "INVALID"
+          , TXPentry numb "2" "63" "INVALID"
+          ]
+    convertTextCalib txf txps `shouldBe`
+      Right (TextualCalibration
+        { _calibTName = numb
+        , _calibTDescr = desc
+        , _calibTRawFmt = NumUInteger
+        , _calibTPoints = V.fromList
+          [ TextCalibPoint 5 62 "INVALID"
+          , TextCalibPoint 2 63 "INVALID"
+          ]
+        })
+
+  it "can convert MCF" $ do
+    let numb = "201"
+    let desc = "TM Poly Curve 1"
+    let mcf = MCFentry numb desc
+          (ShortTextDefaultTo "0.5") (ShortTextDefaultTo "-0.4")
+          (ShortTextDefaultTo "0.3") (ShortTextDefaultTo "-0.2")
+          (ShortTextDefaultTo "0.1")
+
+    convertPolyCalib mcf `shouldBe`
+      Right (PolynomialCalibration
+        { _calibPName = numb
+        , _calibPDescr = desc
+        , _pa0 =  0.5
+        , _pa1 = -0.4
+        , _pa2 =  0.3
+        , _pa3 = -0.2
+        , _pa4 =  0.1
+        })
+
+  it "can convert LGF" $ do
+    let numb = "204"
+    let desc = "LOG Curve 1"
+    let lgf = LGFentry numb desc
+          (ShortTextDefaultTo "0.5") (ShortTextDefaultTo "-0.4")
+          (ShortTextDefaultTo "0.3") (ShortTextDefaultTo "-0.2")
+          (ShortTextDefaultTo "0.1")
+    convertLogCalib lgf `shouldBe`
+      Right (LogarithmicCalibration
+        { _calibLName = numb
+        , _calibLDescr = desc
+        , _la0 =  0.5
+        , _la1 = -0.4
+        , _la2 =  0.3
+        , _la3 = -0.2
+        , _la4 =  0.1
+        })

--- a/esa-mib/test/Spec/Parser.hs
+++ b/esa-mib/test/Spec/Parser.hs
@@ -1,0 +1,151 @@
+
+module Spec.Parser (parserSpec) where
+
+import           Test.Hspec
+import           Data.Char (ord)
+import           Data.ByteString.Lazy (ByteString)
+import qualified Data.Vector as V
+import qualified Data.Csv as Csv
+
+import           Data.MIB.Types
+import           Data.MIB.CAF
+import           Data.MIB.CAP
+import           Data.MIB.CUR
+import           Data.MIB.GPC
+import           Data.MIB.GPF
+import           Data.MIB.LGF
+import           Data.MIB.MCF
+import           Data.MIB.PCF
+import           Data.MIB.PIC
+import           Data.MIB.PID
+import           Data.MIB.PLF
+import           Data.MIB.TPCF
+import           Data.MIB.TXF
+import           Data.MIB.TXP
+import           Data.MIB.VDF
+import           Data.MIB.VPD
+
+
+parse :: Csv.FromRecord a => ByteString -> Either String (V.Vector a)
+parse = Csv.decodeWith opts Csv.NoHeader
+  where
+    opts = Csv.DecodeOptions $ fromIntegral $ ord '\t'
+
+test :: (Csv.FromRecord a, Eq a, Show a) => ByteString -> [a] -> Expectation
+test str res = parse str `shouldBe` Right (V.fromList res)
+
+parserSpec :: Spec
+parserSpec = describe "MIB parser" $ do
+
+  it "parses CAF" $ test
+    "5\tTM Num Curve 5\tR\tR\tD\tOhm\t2"
+    [CAFentry "5" "TM Num Curve 5" 'R' 'R' 'D' "Ohm" 2 (CharDefaultTo 'F')]
+
+  it "parses CAP" $ test
+    ("8\t1\t0.11111\n" <> "2\tFFFFFF\t10")
+    [ CAPentry "8" "1" "0.11111"
+    , CAPentry "2" "FFFFFF" "10"
+    ]
+
+  it "parses CUR" $ test
+    "S2KTP201\t4\tS2KUDC11\t4\t101"
+    [CURentry "S2KTP201" 4 "S2KUDC11" 4 "101"]
+
+  it "parses GPC" $ test
+    ("S2KGRD06\t1\t1\tS2KTP311\tU\t0\t32767\t2\t5\t0\t\n"
+    <> "S2KGRD07\t1\t1\tS2KTP402\tC\t0\t8.25953e+06\t1\t6\t1\t")
+    [ GPCentry
+        "S2KGRD06" 1 '1' "S2KTP311" (CharDefaultTo 'U') "0" "32767" '2'
+        (CharDefaultTo '5') (CharDefaultTo '0') Nothing
+    , GPCentry
+        "S2KGRD07" 1 '1' "S2KTP402" (CharDefaultTo 'C') "0" "8.25953e+06" '1'
+        (CharDefaultTo '6') (CharDefaultTo '1') Nothing
+    ]
+
+  it "parses GPF" $ test
+    "S2KGRD07\tF\tFull White\tN\tN\t0\t0\t5\t7\t10\t1\t1\t1\t10000"
+    [GPFentry
+      "S2KGRD07" 'F' "Full White"
+      (CharDefaultTo 'N') (CharDefaultTo 'N')
+      0 0 5 '7' 10 1 1 1 (Just 16)
+    ]
+
+  it "parses LGF" $ test
+    "204\tLOG Curve 1\t0.5\t-0.4\t0.3\t-0.2\t0.1"
+    [LGFentry "204" "LOG Curve 1"
+      (ShortTextDefaultTo "0.5") (ShortTextDefaultTo "-0.4")
+      (ShortTextDefaultTo "0.3") (ShortTextDefaultTo "-0.2")
+      (ShortTextDefaultTo "0.1")
+    ]
+
+  it "parses MCF" $ test
+    "201\tTM Poly Curve 1\t0.5\t-0.4\t0.3\t-0.2\t0.1"
+    [MCFentry "201" "TM Poly Curve 1"
+      (ShortTextDefaultTo "0.5") (ShortTextDefaultTo "-0.4")
+      (ShortTextDefaultTo "0.3") (ShortTextDefaultTo "-0.2")
+      (ShortTextDefaultTo "0.1")
+    ]
+
+  it "parses PCF" $ test
+     ("MISC08\tTM_PKT_MAX_DELAY\t\tmsec\t4\t14\t\t\t\tN\tR\t\tF\tN\t2\t\t\t1\t\n"
+     <> "OBSMDAT0\tDUMP DATA 0\t\t\t3\t14\t\t\t\tN\tR\t\t\tN\t\t\t\t1\t\n"
+     <> "S2KSPS10\tSAVED SYNTH 10\t\t\t13\t0\t\t\tS2KSPSD7\tN\tS\t\tF\tN\t2\t\t\t1\t")
+    [ PCFentry
+      "MISC08" "TM_PKT_MAX_DELAY"
+      Nothing "msec" 4 14 Nothing "" "" 'N' 'R' "" (CharDefaultTo 'F')
+      (CharDefaultTo 'N') (Just 2) "" "" (DefaultTo 1) ""
+      (CharDefaultTo 'Y') Nothing Nothing Nothing
+    , PCFentry
+      "OBSMDAT0" "DUMP DATA 0"
+      Nothing "" 3 14 Nothing "" "" 'N' 'R' "" (CharDefaultTo 'F')
+      (CharDefaultTo 'N') Nothing "" "" (DefaultTo 1) ""
+      (CharDefaultTo 'Y') Nothing Nothing Nothing
+    , PCFentry
+      "S2KSPS10" "SAVED SYNTH 10"
+      Nothing "" 13 0 Nothing "" "S2KSPSD7" 'N' 'S' "" (CharDefaultTo 'F')
+      (CharDefaultTo 'N') (Just 2) "" "" (DefaultTo 1) ""
+      (CharDefaultTo 'Y') Nothing Nothing Nothing
+    ]
+
+  it "parses PIC" $ test
+    "1\t2\t21\t16\t-1\t0"
+    [PICentry 1 2 21 16 (-1) 0 Nothing]
+
+  it "parses PID" $ test
+    "5\t15\t19\t0\t0\t106\t70 Repeats\t0\t23\t16\tY\t\tY\t1\tN\t"
+    [PIDentry
+      5 15 19 0 0 106
+      "70 Repeats" "0" 23 16
+      (CharDefaultTo 'N') Nothing (CharDefaultTo 'Y')
+      (DefaultTo 1) (CharDefaultTo 'N') ""
+    ]
+
+  it "parses PLF" $ test
+    "CMDMOD\t979\t4\t0\t1\t0\t0\t0"
+    [PLFentry "CMDMOD" 797 4 0 (Just 1) (Just 0) (DefaultTo 0) (Just 0)]
+
+  it "parses TPCF" $ test
+    "11\tS2KTM011\t102"
+    [TPCFentry 11 "S2KTM011" (Just 102)]
+
+  it "parses TXF" $ test
+    "136\tTM Text curve 36\tU\t16"
+    [TXFentry "136" "TM Text curve 36" 'U' (Just 16)]
+
+  it "parses TXP" $ test
+    "106\t1\t62\tINVALID"
+    [TXPentry "106" "1" "62" "INVALID"]
+
+  it "parses VDF" $ test
+    "RTE50\tRTE Data Bse\t0\t1\t0"
+    [VDFentry "RTE50" "RTE Data Bse" (Just 0) (DefaultTo 1) (DefaultTo 0)]
+
+  it "parses VPD" $ test
+    "5\t4\tS2KTP023\t0\t0\tN\tN\tEVID\t6\tR\tN\t0\tH\t0"
+    [VPDentry
+      5 4 "S2KTP023"
+      (DefaultTo 0) (DefaultTo 0) (CharDefaultTo 'N') (CharDefaultTo 'N')
+      "EVID" 6
+      (CharDefaultTo 'L') (CharDefaultTo 'N') (DefaultTo 0)
+      (CharDefaultTo 'H') (DefaultTo 0)
+    ]


### PR DESCRIPTION
- [x] unit tests for cassava `FromRecord`
- [x] low-boilerplate parser generator
- [x] unit tests for conversions
- [x] applicative style in conversions

I added unit tests for each of the `FromRecord` instances but for VDF and LGF
there is not enough data in `ASCII_RTE` folder [`vfd.dat`](https://github.com/oswald2/AURIS/blob/b033eee0037083f1806bbf6677e2e24fc4d70530/esa-mib/ASCII_RTE/vdf.dat) contains single entry
which appears to be invalid and [`lgf.dat`](https://github.com/oswald2/AURIS/blob/b033eee0037083f1806bbf6677e2e24fc4d70530/esa-mib/ASCII_RTE/lgf.dat) is just empty.

Also added unit tests for calibration conversions. Not sure if they are adequate, please check.

Some parsers check input record length with `(>=)`. E.g. can input for `PCFentry` really be longer than 23?
https://github.com/oswald2/AURIS/blob/0712070ebb4ffd4c13b609629f23ad28820f670b/esa-mib/src/Data/MIB/PCF.hs#L95-L97
PCF also provides some defaults in case input is a bit shorter.
https://github.com/oswald2/AURIS/blob/0712070ebb4ffd4c13b609629f23ad28820f670b/esa-mib/src/Data/MIB/PCF.hs#L145
Can the length be 21? In this case should parser overwrite fields 19 and 20 with defaults?
