### PR TITLE
Haskell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ stack_opt.yaml.orig
 stack_llvm.yaml.orig
 a.out
 stack_llvm.yaml.lock
+result

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Telemetry Packet Display:
 ![TM Packet Display](screenshots/TMPackets.png)
 
 Graphical Parameter Display:
-
+➜
 ![TM Parameter Display](screenshots/GRD.png)
 
 
@@ -35,7 +35,6 @@ There are 3 stack.yaml files provided:
  * stack_opt.yaml: this is for the optimized build (much slower)
  * stack_llvm:yaml: optimized build via LLVM (much much slower)
 
-
 Some users have reported build issues with fltkhs. As a workaround, you can just install fltkhs before building AURIS.
 
 ```
@@ -46,8 +45,27 @@ cd <path to AURIS checkout>
 stack build
 ```
 
+### Using nix
 
- ## Data Processing
+This project can also be built using `nix-build`. This will use
+[https://github.com/input-output-hk/haskell.nix](haskell.nix) to derive nix
+expressions from the `stack.yaml` and then build the local packages using the
+same versions as in the stackage `resolver` and `extra-deps`. However many of
+the packages might not be pre-built, but you can try to use `cachix` from
+`iohk`:
+
+``` sh
+cachix use iohk
+nix-build -A esa-space-protocols.components.all
+ls result/bin
+# CommandingAD  CommandingTest  EventLoggingDBTest  TMModelTest  TMSimulatorTest  WriteConfig
+```
+
+There is also a `shell.nix` which provides build tools and dependencies like `ghc`, `cabal` and `stack` and `ghcide`. Inside the shell you can build using `cabal` and `stack --no-nix --system-ghc --no-install-ghc`, or let `stack --nix` use the `shell.nix` (but this requires `stack` on your host system).
+
+If you have [https://github.com/target/lorri](lorri) set up, you get this things even set up when cd'ing in this environment!
+
+## Data Processing
 
 The architecture of the data processing backend looks like this:
 

--- a/aurisi/aurisi.cabal
+++ b/aurisi/aurisi.cabal
@@ -14,6 +14,8 @@ cabal-version: >=2.0
 extra-source-files:
     src/AURISi.fl
 
+extra-source-files:
+  theme.tar.gz
 
 source-repository head
   type: git

--- a/default.nix
+++ b/default.nix
@@ -24,9 +24,23 @@ in pkgs.haskell-nix.stackProject {
     name = "AURIS";
     src = ./.;
   };
-  modules = [
-    {
-      # packages.fltkhs.flags.bundled = false;
-    }
-  ];
+  modules = [{
+    # Bundled FLTK breaks when configured without "--libdir" (custom Setup.hs)
+    packages.fltkhs.flags.bundled = false;
+    # fltkhs is not correctly depended upon in fltkhs.cabal
+    packages.fltkhs.components.library.libs = [ pkgs.fltk14 pkgs.libjpeg ];
+    packages.fltkhs.components.library.build-tools =
+      [ pkgs.fltk14 pkgs.autoconf ];
+    # NOTE(SN): these libs might only be required when linking exes
+    packages.Chart-fltkhs.components.library.libs = [
+      pkgs.fontconfig
+      pkgs.libpng
+      pkgs.xorg.libX11
+      pkgs.xorg.libXext
+      pkgs.xorg.libXfixes
+      pkgs.xorg.libXft
+      pkgs.xorg.libXrender
+      pkgs.zlib
+    ];
+  }];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,7 @@
 let
-  haskell-nix-src = (import <nixpkgs> { }).fetchgit {
+  haskell-nix-src = builtins.fetchGit {
     url = "https://github.com/input-output-hk/haskell.nix";
-    rev = "6cf92c4e983f346123e41dac237ca2cc5c4b9ff6";
-    sha256 = "0q6bpfyqpimkd9hh727cwd6qf1jc5fqvl3mrgw0im5dja6djvvg9";
+    rev = "1383a63ff6005bba577635b9e054375dc7a296d0";
   };
   haskellNix = (import haskell-nix-src) { };
 
@@ -18,29 +17,11 @@ let
   # import nixpkgs with overlays
   # pkgs = import nixpkgs nixpkgsArgs;
   pkgs = import nixpkgsSrc nixpkgsArgs;
-
-in pkgs.haskell-nix.stackProject {
+in
+pkgs.haskell-nix.stackProject {
   src = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "AURIS";
     src = ./.;
   };
-  modules = [{
-    # Bundled FLTK breaks when configured without "--libdir" (custom Setup.hs)
-    packages.fltkhs.flags.bundled = false;
-    # fltkhs is not correctly depended upon in fltkhs.cabal
-    packages.fltkhs.components.library.libs = [ pkgs.fltk14 pkgs.libjpeg ];
-    packages.fltkhs.components.library.build-tools =
-      [ pkgs.fltk14 pkgs.autoconf ];
-    # NOTE(SN): these libs might only be required when linking exes
-    packages.Chart-fltkhs.components.library.libs = [
-      pkgs.fontconfig
-      pkgs.libpng
-      pkgs.xorg.libX11
-      pkgs.xorg.libXext
-      pkgs.xorg.libXfixes
-      pkgs.xorg.libXft
-      pkgs.xorg.libXrender
-      pkgs.zlib
-    ];
-  }];
+  modules = [{ }];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,32 @@
+let
+  haskell-nix-src = (import <nixpkgs> { }).fetchgit {
+    url = "https://github.com/input-output-hk/haskell.nix";
+    rev = "6cf92c4e983f346123e41dac237ca2cc5c4b9ff6";
+    sha256 = "0q6bpfyqpimkd9hh727cwd6qf1jc5fqvl3mrgw0im5dja6djvvg9";
+  };
+  haskellNix = (import haskell-nix-src) { };
+
+  # haskell.nix provides access to the nixpkgs pins which are used by our CI, hence
+  # you will be more likely to get cache hits when using these.
+  # But you can also just use your own, e.g. '<nixpkgs>'
+  nixpkgsSrc = haskellNix.sources.nixpkgs-2003;
+
+  # haskell.nix provides some arguments to be passed to nixpkgs, including some patches
+  # and also the haskell.nix functionality itself as an overlay.
+  nixpkgsArgs = haskellNix.nixpkgsArgs;
+
+  # import nixpkgs with overlays
+  # pkgs = import nixpkgs nixpkgsArgs;
+  pkgs = import nixpkgsSrc nixpkgsArgs;
+
+in pkgs.haskell-nix.stackProject {
+  src = pkgs.haskell-nix.haskellLib.cleanGit {
+    name = "AURIS";
+    src = ./.;
+  };
+  modules = [
+    {
+      # packages.fltkhs.flags.bundled = false;
+    }
+  ];
+}

--- a/esa-space-protocols/src/Data/PUS/ExtractedPUSPacket.hs
+++ b/esa-space-protocols/src/Data/PUS/ExtractedPUSPacket.hs
@@ -15,7 +15,7 @@ import           Data.PUS.PUSPacket
 import           Data.PUS.ExtractedDU
 
 
-  -- | This is a data structure which is used internally in the conduits 
+-- | This is a data structure which is used internally in the conduits 
 -- while extracting packets. Basically, it contains the binary 'ByteString'
 -- from which the packet has been extracted (this is also needed later in the
 -- chain after the packet has been extracted) and the 'ExtractedDU' for the 

--- a/esa-space-protocols/src/Data/PUS/TMFrameExtractor.hs
+++ b/esa-space-protocols/src/Data/PUS/TMFrameExtractor.hs
@@ -160,7 +160,7 @@ setupFrameSwitcher interf outQueue = do
 
   
   
-  -- | Conduit for switching between multiple channels. It queries the 'Config'
+-- | Conduit for switching between multiple channels. It queries the 'Config'
 -- for a list of configured virtual channels, sets up queues for these channels
 -- and a map to switch between these. Per virtual channel a 'tmFrameExtractionChain'
 -- is run (each in its own thread).

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+let
+  pkgs = import <nixpkgs> { };
+  hsPkgs = import ./default.nix;
+in
+hsPkgs.shellFor {
+  packages = ps: [ ps.esa-space-protocols ];
+
+  # Builds a Hoogle documentation index of all dependencies,
+  # and provides a "hoogle" command to search the index.
+  # withHoogle = true;
+  withHoogle = false;
+
+  # Haskell tools compiled using haskell.nix
+  # See overlays/tools.nix for more details
+  # tools = { cabal = "3.2.0.0"; hlint = "2.2.11"; };
+  # tools = { ghcide = "0.2.0"; };
+
+  # Other packages (compiled using nixpkgs haskell infrastructure)
+  buildInputs = [
+    pkgs.cabal-install
+    pkgs.stack
+    # pkgs.haskell.packages.ghc865.ghcide
+  ];
+
+  # Prevents cabal from choosing alternate plans, so that
+  # *all* dependencies are provided by Nix.
+  # exactDeps = true;
+}


### PR DESCRIPTION
Add `default.nix` and `shell.nix` to build and develop using the new nix haskell architecture https://github.com/input-output-hk/haskell.nix